### PR TITLE
Fix HIT Expiration Issue

### DIFF
--- a/mturkTools.js
+++ b/mturkTools.js
@@ -123,7 +123,6 @@ const makeHIT = (title, description, assignmentDuration, lifetime, reward, autoA
     Question: externalHIT(taskURL)
   };
 
-
   mturk.createHIT(makeHITParams, (err, data) => {
     if (err) console.log(err, err.stack);
     else {
@@ -139,7 +138,7 @@ const makeHIT = (title, description, assignmentDuration, lifetime, reward, autoA
 //
 // Takes HIT ID as parameter.
 
-const returnHIT = (hitId, ) => {
+const returnHIT = (hitId) => {
   var returnHITParams = {
     HITId: hitId /* required */
   };
@@ -153,19 +152,14 @@ const returnHIT = (hitId, ) => {
 // -------------------------------------------------------------------
 // Expires all active HITs by updating the time-until-expiration to 0.
 // Users who have already accepted the HIT should still be able to finish and submit.
+//
+// Takes a HIT ID as a parameter
 
-const expireActiveHits = () => {
-  mturk.listHITs({}, (err, data) => {
-    if (err) console.log(err, err.stack);
-    else {
-      data.HITs.map((hit) => {
-        mturk.updateExpirationForHIT({HITId: hit.HITId,ExpireAt:0}, (err, data) => {
-          if (err) { console.log(err, err.stack)
-          } else {console.log("Expired HIT:", hit.HITId)}
-        });
-      })
-    }
-  })
+const expireActiveHits = (HIT) => {
+  mturk.updateExpirationForHIT({HITId: HIT,ExpireAt:0}, (err, data) => {
+    if (err) { console.log(err, err.stack)
+    } else {console.log("Expired HIT:", HIT)}
+  });
 }
 
 // * deleteHIT *
@@ -328,6 +322,14 @@ const checkBlocks = (removeBlocks = false) => {
   })
 }
 
+// * returnCurrentHIT *
+// -------------------------------------------------------------------
+// Returns the current active HIT ID
+
+const returnCurrentHIT = () => {
+  return currentHitId;
+}
+
 // * launchBang *
 // -------------------------------------------------------------------
 // Launches Scaled-Humanity Fracture experiment
@@ -439,6 +441,7 @@ module.exports = {
   bonusPrice: bonusPrice,
   blockWorker: blockWorker,
   checkBlocks: checkBlocks,
+  returnCurrentHIT: returnCurrentHIT,
   submitTo: submitTo,
   launchBang: launchBang
 };

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const roundMinutes = process.env.ROUND_MINUTES
 // Toggles
 const runExperimentNow = true
 const issueBonusesNow = true
-const cleanHITs = false
+const cleanHITs = true
 const assignQualifications = false
 const debugMode = !runningLive
 
@@ -109,6 +109,7 @@ const Datastore = require('nedb'),
     db.midSurvey = new Datastore({ filename:'.data/midSurvey', autoload: true}); // to store midSurvey results
     db.batch = new Datastore({ filename:'.data/batch', autoload: true}); // to store batch information
     db.time = new Datastore({ filename:'.data/time', autoload: true}); // store duration of tasks
+    db.ourHITs = new Datastore({ filename:'.data/ourHITs', autoload: true}); // separate fracture HITs from other HCI hits
 
 
 const updateUserInDB = (user,feild,value) => { db.users.update(
@@ -137,7 +138,17 @@ if (runningLive){
   })
 }
 
-if (cleanHITs){ mturk.expireActiveHits() }
+// expires HITs left in the DB
+if (cleanHITs){ 
+  db.ourHITs.find({}, (err, HITsInDB) => {
+    if (err) {console.log("Err loading HITS for expiration:" + err)} else {
+      HITsInDB.forEach((HIT) => {
+        let currentHIT = HIT.currentHIT;
+        mturk.expireActiveHits(currentHIT);
+      })
+    }
+  })
+}
 if (runExperimentNow){ mturk.launchBang() }
 
 //Add more products
@@ -202,6 +213,15 @@ db.batch.insert({'batchID': batchID, 'starterSurveyOn':starterSurveyOn,'midSurve
       firstRun = true;
     }
 }); // task_list instead of all of the toggles? (missing checkinOn)
+
+// Timer to catch ID after HIT has been posted - this is sketchy, as unknown when HIT will be posted
+setTimeout(() => {
+  let currentHIT = mturk.returnCurrentHIT();
+  db.ourHITs.insert({'currentHIT': currentHIT}, (err, HITAdded) => {
+    if(err) console.log("There's a problem adding HIT to the DB: ", err);
+    else if(HITAdded) console.log("HIT added to the DB: ", currentHIT);
+  })
+}, 1000 * 12)
 
 // Chatroom
 io.on('connection', (socket) => {
@@ -359,6 +379,13 @@ io.on('connection', (socket) => {
 
           if (!taskOver && suddenDeath){
             // Start cancel process
+
+            let currentHIT = mturk.returnCurrentHIT();
+            db.ourHITs.insert({'currentHIT': currentHIT}, (err, HITAdded) => {
+              if(err) console.log("There's a problem adding HIT to the DB: ", err);
+              else if(HITAdded) console.log("HIT added to the DB: ", currentHIT);
+            })
+
             console.log("User left, emitting cancel to all users");
 
             let totalTime = getSecondsPassed();
@@ -473,6 +500,12 @@ io.on('connection', (socket) => {
         }
         user.bonus += mturk.bonusPrice
         updateUserInDB(user,"bonus",user.bonus)
+
+        let currentHIT = mturk.returnCurrentHIT();
+        db.ourHITs.insert({'currentHIT': currentHIT}, (err, HITAdded) => {
+          if(err) console.log("There's a problem adding HIT to the DB: ", err);
+          else if(HITAdded) console.log("HIT added to the DB: ", currentHIT);
+        })
 
         io.in(socket.id).emit('finished', {
           message: "Thanks for participating, you're all done!",


### PR DESCRIPTION
Added new datastore 'ourHITs' to track the HIT ID's of the HITs we have created. expireActiveHITs() now takes a HIT ID as a parameter and only expires the HIT ID that is passed in. Upon launch, all HIT IDs logged in ourHITs are expired.

One sketchy thing - the HIT ID is added to the DB after a timer - this was because it needs to wait for the HIT to be posted from the MTurk side for a HIT ID to be available to add to the DB. Right now it's on a 12 second timer, which is typically plenty of time. It works, but if you know of a better way to do this please let me know. 