### PR TITLE
hotfix: allowed w/o roster setting

### DIFF
--- a/front/src/containers/admin/AddBatch.js
+++ b/front/src/containers/admin/AddBatch.js
@@ -128,7 +128,7 @@ const validate = (values, props) => {
   if (values.withAvatar == null) {
     errors.withAvatar = 'required'
   }
-  if (!values.withRoster) {
+  if (values.withRoster == null) {
     errors.withRoster = 'required'
   }
 
@@ -141,7 +141,6 @@ AddBatch = reduxForm({
   touchOnChange: true,
   validate,
 })(AddBatch);
-
 function mapStateToProps(state) {
   return {
     templateList: state.template.templateList


### PR DESCRIPTION
for true/false settings in general, the toggle logic should check if value is null