### PR TITLE
Add in Color Differentiation for Group v. Individual Tasks

### DIFF
--- a/front/src/containers/Batch.js
+++ b/front/src/containers/Batch.js
@@ -468,6 +468,31 @@ class Batch extends React.Component {
 
   renderChat() {
     const {sendMessage, user, voteCasualForm, chat, batch, currentRound, vote} = this.props;
+
+
+    // Make the chat look different when they're in an individual round, so that users are less confused.
+
+    if(this.props.currentTeam){ //this starts out as null at the very beginning
+
+      if(this.props.currentTeam.length === 1){ // this means we're an individual.
+        //change background color to green
+        if(document.getElementsByClassName("card-body")[0]){
+          document.getElementsByClassName("card-body")[0].style.backgroundColor = "#12755C" //green
+        }
+        // NOTE: The way that this code is dynamically called makes it impossible to create variable names, hence some repetition.
+        //change the title to alert that it is an individual task
+        if(document.getElementsByClassName("bold-text")){
+          if(document.getElementsByClassName("bold-text")[0].innerHTML.length <= "Round n".length + 1){
+            document.getElementsByClassName("bold-text")[0].innerHTML += " - Individual Task! Please complete this task by yourself."
+          }
+        }
+      }else{
+        if(document.getElementsByClassName("card-body")[0]){
+          document.getElementsByClassName("card-body")[0].style.backgroundColor = "#AA72A1" //magenta
+        }
+      }
+    }
+
     let pinnedContent = [];
     try {
       pinnedContent = batch.tasks[currentRound.number - 1].pinnedContent;

--- a/front/src/containers/Batch.js
+++ b/front/src/containers/Batch.js
@@ -470,29 +470,35 @@ class Batch extends React.Component {
     const {sendMessage, user, voteCasualForm, chat, batch, currentRound, vote} = this.props;
 
 
-    // Make the chat look different when they're in an individual round, so that users are less confused.
-
-    if(this.props.currentTeam){ //this starts out as null at the very beginning
-
-      if(this.props.currentTeam.length === 1){ // this means we're an individual.
-        //change background color to green
-        if(document.getElementsByClassName("card-body")[0]){
-          document.getElementsByClassName("card-body")[0].style.backgroundColor = "#12755C" //green
-        }
-        // NOTE: The way that this code is dynamically called makes it impossible to create variable names, hence some repetition.
-        //change the title to alert that it is an individual task
-        if(document.getElementsByClassName("bold-text")){
-          if(document.getElementsByClassName("bold-text")[0].innerHTML.length <= "Round n".length + 1){
-            document.getElementsByClassName("bold-text")[0].innerHTML += " - Individual Task! Please complete this task by yourself."
+    // DYNAMIC TEAM SIZE: Make the chat look different when they're in an individual round, so that users are less confused.
+    if(batch.dynamicTeamSize){
+      if(this.props.currentTeam){ //this starts out as null at the very beginning
+        if(this.props.currentTeam.length === 1){ // this means we're an individual.
+          //change background color to green
+          if(document.getElementsByClassName("card-body")[0]){
+            document.getElementsByClassName("card-body")[0].style.backgroundColor = "#529A88" //green
           }
-        }
-      }else{
-        if(document.getElementsByClassName("card-body")[0]){
-          document.getElementsByClassName("card-body")[0].style.backgroundColor = "#AA72A1" //magenta
+          // NOTE: The way that this code is dynamically called makes it impossible to create variable names, hence some repetition.
+          //change the title to alert that it is an individual task
+          if(document.getElementsByClassName("bold-text")[0]){
+            if(document.getElementsByClassName("bold-text")[0].innerHTML.length <= "Round n".length + 1 && document.getElementsByClassName("bold-text")[0].innerHTML.length > 0){
+              document.getElementsByClassName("bold-text")[0].innerHTML += " - Individual Task! Please complete this task by yourself."
+            }
+          }
+        }else{
+          if(document.getElementsByClassName("card-body")[0]){
+            document.getElementsByClassName("card-body")[0].style.backgroundColor = "#AA72A1" //magenta
+          }
+          //change the title to alert that it is an group task
+          if(document.getElementsByClassName("bold-text")[0]){
+            if(document.getElementsByClassName("bold-text")[0].innerHTML.length <= "Round n".length + 1 && document.getElementsByClassName("bold-text")[0].innerHTML.length > 0){
+              document.getElementsByClassName("bold-text")[0].innerHTML += " - Group Task! Please complete this task with your team."
+            }
+          }
         }
       }
     }
-
+    
     let pinnedContent = [];
     try {
       pinnedContent = batch.tasks[currentRound.number - 1].pinnedContent;


### PR DESCRIPTION
In pilots, I encountered a problem where participants seemed to think that being in an individual task was a mistake. In fact, they would send me emails, saying "no one else is in my room," even though that was supposed to be the point of the task.

This is a very small PR that only affects the Morality experiment. (It only impacts cases that have **dynamicTeamSize = true**). 

The purpose of this PR is to address the above issue by adding color-scaffolding for individual versus group tasks.

So, a group task will look magneta, like this:
<img width="1107" alt="Screen Shot 2020-03-18 at 8 05 48 PM" src="https://user-images.githubusercontent.com/28793641/77019193-5c9b3180-6956-11ea-8c59-778717e8910a.png">

And an individual task will look green, like this:
<img width="1160" alt="Screen Shot 2020-03-18 at 8 10 13 PM" src="https://user-images.githubusercontent.com/28793641/77019205-63c23f80-6956-11ea-8299-6f4e83486b7f.png">

The code is slightly hacky, because I basically figured out how to change the underlying CSS by inspecting the rounds and doing a little bit of trial and error. However, I tested it repeatedly and it seems to work as expected. If there are any style changes that would make this better, please let me know.