### PR TITLE
Update Newarch Prod with Polls and Case Randomization Updates

### DIFF
--- a/front/src/components/CasualForm.js
+++ b/front/src/components/CasualForm.js
@@ -85,7 +85,7 @@ class CasualForm extends React.Component {
             }
         }
         if(data.questions){
-            if (questions.length !== data.questions.length) {
+            if (questions.length !== data.questions.length && questions.length!=1) { //second condition prevents error message from showing up when there is only the primary question
                 throw new SubmissionError({
                     _error: 'All questions are required'
                 })

--- a/front/src/components/Vote.js
+++ b/front/src/components/Vote.js
@@ -67,7 +67,6 @@ class Vote extends Component {
         this.setState({votes: votes});
         const disabled = Object.values(votes).some(x => +x >= lockCap);
         if (disabled !== this.state.disabled) {
-            this.props.onDisable(pollInd);
             this.setState({disabled: true})
         }
     }
@@ -94,6 +93,9 @@ class Vote extends Component {
             }, pollInd: pollInd
         });
         vote(obj);
+        if(this.state.disabled){
+            this.setState({disabled: false})
+        }
         this.setState({questionResult: question, selectedOption: option});
     }
 

--- a/front/src/components/Vote.js
+++ b/front/src/components/Vote.js
@@ -176,7 +176,6 @@ class Vote extends Component {
                                             }
                                             return <button
                                                 style={style}
-                                                disabled={disabled}
                                                 onClick={() => {
                                                     this.handleVote(option, question)
                                                 }}>

--- a/server/controllers/utils.ts
+++ b/server/controllers/utils.ts
@@ -393,7 +393,13 @@ export const createDynamicTeams = (teamSize: number, numRounds: number) => {
   var sizeNrounds = [];
 
   let roundGen = Array(numRounds);
+
   var generateIndividual = true;
+  if(Math.random() > 0.5){
+    var generateIndividual = false; //add a probability that we start with generating group
+  }
+
+  console.log("Confirming generateIndividual status: " + generateIndividual)
     
   roundPairs.forEach(pair => {
 


### PR DESCRIPTION
This PR accomplishes 3 things:
1. In `utils.ts`, it ensures that each of the two cases is randomly assigned to be either the individual case or the group case. (Previously, Case 0 was always the individual case and Case 1 was always group.) This allows us to calculate consistency _given_ a particular case!
2. It fixes a bug where people got error messages for 'not answering all the questions' when, in fact, they had.
3. It adds the ability for people to change their vote even after the threshold is reached (Issue #506). In my pilots today, someone gave the feedback that they clicked the wrong button, but since their vote was the vote that passed the 'success' threshold, they were not able to change their vote. This is especially true of all individual rounds (since the threshold is one, any mis-clicks cause noise in our data because they can't be un-done).

I've tested all of them extensively and they work, and since they're very small fixes, I pushed them directly into newarch.

---
The reason why I'm pausing this for review is that my implementation of the Polls fix introduces a small known bug:
- Typically, if you don't meet the "win threshold" for a poll, there is supposed to be an error/warning that says enough people haven't come to agreement yet:
<img width="641" alt="Screen Shot 2020-03-27 at 10 10 30 PM" src="https://user-images.githubusercontent.com/28793641/77812463-d5496e80-7077-11ea-9f47-a6b93e891d26.png">
- With the new code, if you **reach the threshold, and then change your vote**, thus making the overall vote no longer meet the threshold, then the "you haven't met the threshold" warning only appears for the person who changed their vote. It doesn't show up or update for anyone else unless they also change their votes.

- For everyone else, they still see the original winner:
<img width="766" alt="Screen Shot 2020-03-27 at 10 09 59 PM" src="https://user-images.githubusercontent.com/28793641/77812478-eb572f00-7077-11ea-8c77-bf7a17a5ac8e.png">
- Previously, this wasn't an issue because once the threshold was met, further changes were frozen, so this would never happen.


The way to fix this (to my understanding) is to force the system to update the state. But no matter what I did, I got an error that said "max stack frame exceeded," so I erred on the side of updating less.

The question is: **are we okay with the tradeoff between this bug and the ability to have people change their votes?**